### PR TITLE
fix formatting on ts code block

### DIFF
--- a/content/GraphQL-Binding/04-Creating-your-own-Binding.md
+++ b/content/GraphQL-Binding/04-Creating-your-own-Binding.md
@@ -104,9 +104,9 @@ The `mutation` property represents the fields of the `Mutation` type from the ab
 
 The `subscription` property represents the fields of the `Subscription` type from the above GraphQL schema.
 
-    ```ts
-  userCreated: (args: <T = User>{}, info?: GraphQLResolveInfo | string, context?: { [key: string]: any }) =>  Promise<AsyncIterator<any>>
-    ```
+```ts
+userCreated: (args: <T = User>{}, info?: GraphQLResolveInfo | string, context?: { [key: string]: any }) =>  Promise<AsyncIterator<any>>
+```
 
 #### Generating TypeScript type definitions for the `UserServiceBinding` class
 


### PR DESCRIPTION
This fixes the formatting of the `ts` code block that's currently out of shape.