### PR TITLE
fix(generatorcli): generator cli docs

### DIFF
--- a/content/GraphQL-Binding/03-Generator-CLIs.md
+++ b/content/GraphQL-Binding/03-Generator-CLIs.md
@@ -34,6 +34,26 @@ Options:
   --outputTypedefs, -t  Output type defs. Example: typeDefs.graphql    [string]
 ```
 
+### Generating a Binding
+
+We're going to generate a GraphQL binding for the following [schema](https://github.com/graphql-binding/graphql-binding-example-service/blob/master/src/schema.js).
+
+```sh
+graphql-binding -i ./src/schema.js -l javascript -b binding.js
+```
+
+This will create a GraphQL Binding like [this](https://github.com/graphql-binding/graphql-binding-example-service/blob/master/src/index.js)
+
+### Generating Type Definitions
+
+We can add the `-t` flag to our command to output type definitions in a `.graphql` file.
+
+```sh
+graphql-binding -i ./src/schema.js -l javascript -b binding.js -t typeDefs.graphql
+```
+
+This will create a  [`typeDefs.graphql`](https://github.com/graphql-binding/graphql-binding-example-service/blob/master/src/typeDefs.graphql).
+
 ### Usage with GraphQL Config
 
 The `graphql-binding` CLI integrates with GraphQL Config. This means instead of passing arguments to the command, you can write a `.graphqlconfig.yml` file which will be read by the CLI.
@@ -53,13 +73,10 @@ projects:
             binding: mybinding.ts
 ```
 
-Invoking simply `graphql codegen` in a directory where the above `.graphqlconfig` is available is equivalent to invoking the following terminal command:
+Invoking `graphql codegen` in a directory where the above `.graphqlconfig` is available is equivalent to invoking the following terminal command:
 
 ```sh
-graphql-binding \
-  --language typescript \
-  --input schema.js \
-  --outputBinding mybinding.ts
+graphql-binding --language typescript --input schema.js --outputBinding mybinding.ts
 ```
 
 ## `prisma-binding`
@@ -71,6 +88,8 @@ Install with `npm`:
 ```sh
 npm install -g prisma-binding
 ```
+
+OR
 
 Install with `yarn`:
 
@@ -114,39 +133,7 @@ projects:
 Invoking simply `graphql codegen` in a directory where the above `.graphqlconfig` is available is equivalent to invoking the following terminal command:
 
 ```sh
-prisma-binding \
-  --language typescript \
-  --outputBinding mybinding.ts
-```
-
-### Upgrading from `prisma-binding` v1.X
-
- Versions lower than 2.0 of `prisma-binding` were based on the `graphql prepare` instead of the `graphql codegen` command. Here is how you need to update your Prisma project files to account for the changes:
-
- **prisma.yml**
-
-```yml
-# ... other properties
-
-hooks:
-  post-deploy:
-    - graphql get-schema
-    - graphql codegen
-```
-
-**.graphqlconfig.yml**
-
-```yml
-projects:
-  myapp:
-    schemaPath: src/generated/prisma.graphql
-    extensions:
-      prisma: prisma/prisma.yml
-      codegen:
-        - generator: prisma-binding
-          language: typescript
-          output:
-            binding: src/generated/prisma.ts
+prisma-binding --language typescript --outputBinding mybinding.ts
 ```
 
 ## Writing your own generator CLI

--- a/content/GraphQL-Binding/03-Generator-CLIs.md
+++ b/content/GraphQL-Binding/03-Generator-CLIs.md
@@ -46,7 +46,7 @@ This will create a GraphQL Binding like [this](https://github.com/graphql-bindin
 
 ### Generating Type Definitions
 
-We can add the `-t` flag to our command to output type definitions in a `.graphql` file.
+We can add the `--outputTypedefs` flag to our command to output type definitions in a `.graphql` file.
 
 ```sh
 graphql-binding --input ./src/schema.js --language javascript --outputBinding binding.js --outputTypedefs typeDefs.graphql

--- a/content/GraphQL-Binding/03-Generator-CLIs.md
+++ b/content/GraphQL-Binding/03-Generator-CLIs.md
@@ -39,7 +39,7 @@ Options:
 We're going to generate a GraphQL binding for the following [schema](https://github.com/graphql-binding/graphql-binding-example-service/blob/master/src/schema.js).
 
 ```sh
-graphql-binding -i ./src/schema.js -l javascript -b binding.js
+graphql-binding --input ./src/schema.js --language javascript --outputBinding binding.js
 ```
 
 This will create a GraphQL Binding like [this](https://github.com/graphql-binding/graphql-binding-example-service/blob/master/src/index.js)
@@ -49,7 +49,7 @@ This will create a GraphQL Binding like [this](https://github.com/graphql-bindin
 We can add the `-t` flag to our command to output type definitions in a `.graphql` file.
 
 ```sh
-graphql-binding -i ./src/schema.js -l javascript -b binding.js -t typeDefs.graphql
+graphql-binding --input ./src/schema.js --language javascript --outputBinding binding.js --outputTypedefs typeDefs.graphql
 ```
 
 This will create a  [`typeDefs.graphql`](https://github.com/graphql-binding/graphql-binding-example-service/blob/master/src/typeDefs.graphql).

--- a/content/GraphQL-Binding/04-Creating-your-own-Binding.md
+++ b/content/GraphQL-Binding/04-Creating-your-own-Binding.md
@@ -30,7 +30,7 @@ The GraphQL API above is deployed to this URL: `https://graphql-binding-example-
 
 #### Extending the `Binding` class
 
-To create your own binding for this API starts by turning the deployed GraphQL API into a [remote executable schema](https://blog.graph.cool/how-do-graphql-remote-schemas-work-7118237c89d7) using the `makeRemoteExecutableSchema` function from the [`graphql-tools`](https://www.apollographql.com/docs/graphql-tools/) library and then use this remote schema to extend the `Binding` class from the `graphql-binding` package.
+To create your own binding for this API, you start by turning the deployed GraphQL API into a [remote executable schema](https://www.prisma.io/blog/how-do-graphql-remote-schemas-work-7118237c89d7/) using the `makeRemoteExecutableSchema` function from the [`graphql-tools`](https://www.apollographql.com/docs/graphql-tools/) library and then use this remote schema to extend the `Binding` class from the `graphql-binding` package.
 
 Here's what that could look like:
 
@@ -156,7 +156,7 @@ projects:
 Now invoking the `graphql codegen` command has the same effect as using the `graphql-binding` CLI with the `language`, `input` and `outputBinding` arguments.
 
 ```sh
-graphql-binding -l typescript -i schema.js -b mybinding.ts
+graphql-binding --language typescript --input schema.js --outputBinding mybinding.ts
 ```
 
 #### Using the `ExampleServiceBinding` class
@@ -228,7 +228,7 @@ class UserServiceBinding extends Binding {
 
 #### Using the `UserServiceBinding` class
 
-Here an examplary call you can now make with your `UserServiceBinding` class:
+An examplary call you can now make with your `UserServiceBinding` class:
 
 ```js
 const userServiceBinding = new UserServiceBinding();
@@ -285,7 +285,7 @@ class UserDBBinding extends Binding {
 
 #### Using the `UserDBBinding` class
 
-Here an examplary call you can now make with your `UserServiceBinding` class:
+An examplary call you can now make with your `UserDBBinding` class:
 
 ```js
 const userDBBinding = new UserDBBinding();


### PR DESCRIPTION
@nikolasburk i feel like having prisma binding in the generator clis section is random. It def is a cli that uses graphql-binding, but i feel like this section should be using the basic cli, and give an example of a custom generator

Maybe we can put prisma-binding in prisma docs?