### PR TITLE
fix graphql-import from string example

### DIFF
--- a/content/GraphQL-Import/Overview.md
+++ b/content/GraphQL-Import/Overview.md
@@ -195,7 +195,7 @@ const commentsSchema = `
   }`
 
 const postsSchema = `
-  # import * from 'comments.graphql'
+  # import * from 'commentsSchema'
 
   type Post {
     comments: [Comment]
@@ -205,7 +205,7 @@ const postsSchema = `
   }`
 
 const appSchema = `
-  # import Post from "posts"
+  # import Post from "postsSchema"
 
   type App {
     # test 1


### PR DESCRIPTION
Hi,
I have been following an example of `graphql-import` and found that I have to change import name to match with the key of schemas object,

import statement in an example are not match with schemas key.